### PR TITLE
Use loggly bulk endpoint.

### DIFF
--- a/loggly/adapter/adapter.go
+++ b/loggly/adapter/adapter.go
@@ -1,0 +1,136 @@
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gliderlabs/logspout/router"
+)
+
+const (
+	logglyAddr          = "https://logs-01.loggly.com"
+	logglyEventEndpoint = "/bulk"
+	logglyTagsHeader    = "X-LOGGLY-TAG"
+)
+
+// Adapter satisfies the router.LogAdapter interface by providing Stream which
+// passes all messages to loggly.
+type Adapter struct {
+	token      string
+	client     *http.Client
+	tags       string
+	log        *log.Logger
+	queue      chan logglyMessage
+	bufferSize int
+}
+
+// New returns an Adapter that receives messages from logspout and launches
+// a goroutine to buffer and flush messages to loggly.
+func New(logglyToken, tags string, bufferSize int) *Adapter {
+	client := &http.Client{
+		Timeout: 900 * time.Millisecond, // logspout will cull any spout that does  respond within 1 second
+	}
+
+	adapter := &Adapter{
+		client:     client,
+		bufferSize: bufferSize,
+		log:        log.New(os.Stdout, "logspout-loggly", log.LstdFlags),
+		queue:      make(chan logglyMessage),
+		token:      logglyToken,
+		tags:       tags,
+	}
+
+	go adapter.readQueue()
+
+	return adapter
+}
+
+// Stream satisfies the router.LogAdapter interface and passes all messages to
+// Loggly
+func (l *Adapter) Stream(logstream chan *router.Message) {
+	for m := range logstream {
+		l.queue <- logglyMessage{
+			Message:           m.Data,
+			ContainerName:     m.Container.Name,
+			ContainerID:       m.Container.ID,
+			ContainerImage:    m.Container.Config.Image,
+			ContainerHostname: m.Container.Config.Hostname,
+		}
+	}
+}
+
+func (l *Adapter) readQueue() {
+	buffer := l.newBuffer()
+
+	for msg := range l.queue {
+		if len(buffer) == cap(buffer) {
+			l.flushBuffer(buffer)
+			buffer = l.newBuffer()
+		}
+
+		buffer = append(buffer, msg)
+	}
+}
+
+func (l *Adapter) newBuffer() []logglyMessage {
+	return make([]logglyMessage, 0, l.bufferSize)
+}
+
+func (l *Adapter) flushBuffer(buffer []logglyMessage) {
+
+}
+
+// SendMessage handles creating and sending a request to Loggly. Any errors
+// that occur during that process are bubbled up to the caller
+func (l *Adapter) SendMessage(msg logglyMessage) {
+	js, err := json.Marshal(msg)
+
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	url := fmt.Sprintf("%s%s/%s", logglyAddr, logglyEventEndpoint, l.token)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(js))
+
+	if err != nil {
+		l.log.Println(err)
+		return
+	}
+
+	if l.tags != "" {
+		req.Header.Add(logglyTagsHeader, l.tags)
+	}
+
+	go l.sendRequestToLoggly(req)
+}
+
+func (l *Adapter) sendRequestToLoggly(req *http.Request) {
+	resp, err := l.client.Do(req)
+
+	if err != nil {
+		l.log.Println(
+			fmt.Errorf(
+				"error from client: %s",
+				err.Error(),
+			),
+		)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		l.log.Println(
+			fmt.Errorf(
+				"received a non 200 status code when sending message to loggly: %s",
+				err.Error(),
+			),
+		)
+	}
+}

--- a/loggly/adapter/adapter_test.go
+++ b/loggly/adapter/adapter_test.go
@@ -1,0 +1,1 @@
+package adapter

--- a/loggly/adapter/adapter_test.go
+++ b/loggly/adapter/adapter_test.go
@@ -1,1 +1,35 @@
 package adapter
+
+import "testing"
+
+func TestBuffer(t *testing.T) {
+	bufferSize := 10
+	a := &Adapter{
+		bufferSize: bufferSize,
+	}
+	buf := a.newBuffer()
+
+	if len(buf) != 0 {
+		t.Errorf("expected new buffer length to be 0 but it was %s", len(buf))
+	}
+
+	if cap(buf) != bufferSize {
+		t.Errorf("expected buffer capacity to be %s but it was %s", bufferSize, cap(buf))
+	}
+
+	buf = append(buf, logglyMessage{})
+
+	if len(buf) != 1 {
+		t.Errorf(
+			"expected buffer length to be 1 after adding item but it was %s",
+			len(buf),
+		)
+	}
+
+	oldBuffer := buf
+	newBuffer := a.newBuffer()
+
+	if &oldBuffer == &newBuffer {
+		t.Error("expected oldBuffer and newBuffer to point to different structs")
+	}
+}

--- a/loggly/adapter/loggly_message.go
+++ b/loggly/adapter/loggly_message.go
@@ -1,0 +1,9 @@
+package adapter
+
+type logglyMessage struct {
+	Message           string `json:"message"`
+	ContainerName     string `json:"container_name"`
+	ContainerID       string `json:"container_id"`
+	ContainerImage    string `json:"container_image"`
+	ContainerHostname string `json:"hostname"`
+}

--- a/loggly/loggly.go
+++ b/loggly/loggly.go
@@ -1,33 +1,26 @@
 package loggly
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
-	"net/http"
 	"os"
-	"time"
 
 	"github.com/gliderlabs/logspout/router"
+	"github.com/iamatypeofwalrus/logspout-loggly/loggly/adapter"
 )
 
 const (
-	adapterName         = "loggly"
-	logglyTokenEnvVar   = "LOGGLY_TOKEN"
-	logglyTagsEnvVar    = "LOGGLY_TAGS"
-	filterNameEnvVar    = "FILTER_NAME"
-	logglyTagsHeader    = "X-LOGGLY-TAG"
-	logglyAddr          = "https://logs-01.loggly.com"
-	logglyEventEndpoint = "/inputs"
+	adapterName       = "loggly"
+	filterNameEnvVar  = "FILTER_NAME"
+	logglyTokenEnvVar = "LOGGLY_TOKEN"
+	logglyTagsEnvVar  = "LOGGLY_TAGS"
 )
 
 func init() {
 	router.AdapterFactories.Register(NewLogglyAdapter, adapterName)
 
 	r := &router.Route{
-		Adapter: "loggly",
+		Adapter:    "loggly",
 		FilterName: os.Getenv(filterNameEnvVar),
 	}
 
@@ -48,95 +41,9 @@ func NewLogglyAdapter(route *router.Route) (router.LogAdapter, error) {
 		return nil, errors.New("could not find environment variable LOGGLY_TOKEN")
 	}
 
-	return &Adapter{
-		token: token,
-		client: http.Client{
-			Timeout: 900 * time.Millisecond, // logspout will cull any spout that does  respond within 1 second
-		},
-		tags: os.Getenv(logglyTagsEnvVar),
-		log:  log.New(os.Stdout, "logspout-loggly", log.LstdFlags),
-	}, nil
-}
-
-// Adapter satisfies the router.LogAdapter interface by providing Stream which
-// passes all messages to loggly.
-type Adapter struct {
-	token  string
-	client http.Client
-	tags   string
-	log    *log.Logger
-}
-
-// Stream satisfies the router.LogAdapter interface and passes all messages to
-// Loggly
-func (l *Adapter) Stream(logstream chan *router.Message) {
-	for m := range logstream {
-		msg := logglyMessage{
-			Message:           m.Data,
-			ContainerName:     m.Container.Name,
-			ContainerID:       m.Container.ID,
-			ContainerImage:    m.Container.Config.Image,
-			ContainerHostname: m.Container.Config.Hostname,
-		}
-
-		l.SendMessage(msg)
-	}
-}
-
-// SendMessage handles creating and sending a request to Loggly. Any errors
-// that occur during that process are bubbled up to the caller
-func (l *Adapter) SendMessage(msg logglyMessage) {
-	js, err := json.Marshal(msg)
-
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	url := fmt.Sprintf("%s%s/%s", logglyAddr, logglyEventEndpoint, l.token)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(js))
-
-	if err != nil {
-		l.log.Println(err)
-		return
-	}
-
-	if l.tags != "" {
-		req.Header.Add(logglyTagsHeader, l.tags)
-	}
-
-	go l.sendRequestToLoggly(req)
-}
-
-func (l *Adapter) sendRequestToLoggly(req *http.Request) {
-	resp, err := l.client.Do(req)
-
-	if err != nil {
-		l.log.Println(
-			fmt.Errorf(
-				"error from client: %s",
-				err.Error(),
-			),
-		)
-		return
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		l.log.Println(
-			fmt.Errorf(
-				"received a non 200 status code when sending message to loggly: %s",
-				err.Error(),
-			),
-		)
-	}
-}
-
-type logglyMessage struct {
-	Message           string `json:"message"`
-	ContainerName     string `json:"container_name"`
-	ContainerID       string `json:"container_id"`
-	ContainerImage    string `json:"container_image"`
-	ContainerHostname string `json:"hostname"`
+	return adapter.New(
+		token,
+		os.Getenv(logglyTagsEnvVar),
+		100,
+	), nil
 }


### PR DESCRIPTION
I added a semaphore to allow 15 connections to loggly at a time.
And the response body form loggly gets read and discarded.
This fixes #5 and should make the container more stable against high logging traffic.
A docker image with the fix can be pulled from: quay.io/eversolve/logspout-loggly
