### PR TITLE
Add FILTER_NAME route option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deploy.sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ or you can pull a prebuilt image
 docker run -d \
   -e 'LOGGLY_TOKEN=<token>' \
   -e 'LOGGLY_TAGS=<comma-delimited-list>' \
+  -e 'FILTER_NAME=<wildcard-container-name>' \
   --volume /var/run/docker.sock:/tmp/docker.sock \
   iamatypeofwalrus/logspout-loggly
 ```

--- a/loggly/loggly.go
+++ b/loggly/loggly.go
@@ -17,6 +17,7 @@ const (
 	adapterName         = "loggly"
 	logglyTokenEnvVar   = "LOGGLY_TOKEN"
 	logglyTagsEnvVar    = "LOGGLY_TAGS"
+	filterNameEnvVar    = "FILTER_NAME"
 	logglyTagsHeader    = "X-LOGGLY-TAG"
 	logglyAddr          = "https://logs-01.loggly.com"
 	logglyEventEndpoint = "/inputs"
@@ -27,6 +28,7 @@ func init() {
 
 	r := &router.Route{
 		Adapter: "loggly",
+		FilterName: os.Getenv(filterNameEnvVar),
 	}
 
 	// It's not documented in the logspout repo but if you want to use an adapter
@@ -118,7 +120,7 @@ func (l *Adapter) sendRequestToLoggly(req *http.Request) {
 		)
 		return
 	}
-	
+
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {

--- a/modules.go
+++ b/modules.go
@@ -7,5 +7,5 @@ import (
 	_ "github.com/gliderlabs/logspout/routesapi"
 	_ "github.com/gliderlabs/logspout/transports/tcp"
 	_ "github.com/gliderlabs/logspout/transports/udp"
-	_ "github.com/iamatypeofwalrus/logspout-loggly/loggly"
+	_ "github.com/uaudio/logspout-loggly/loggly"
 )


### PR DESCRIPTION
It's useful when running multiple logspout-loggly containers on one host, to restrict each one to a specific container. This permits you to include different LOGGLY_TAGS for each one.

To merge this, you can safely remove the .gitignore I added, and don't accept the change to modules.go. I've tested this with 2 logspout-loggly containers each reporting to Loggly with separate tags.
