### PR TITLE
Added support of the new logspout

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+apk add --update go git mercurial build-base ca-certificates
+mkdir -p /go/src/github.com/gliderlabs
+cp -r /src /go/src/github.com/gliderlabs/logspout
+cd /go/src/github.com/gliderlabs/logspout
+export GOPATH=/go
+go get
+go build -ldflags "-X main.Version=$1" -o /bin/logspout
+apk del go git mercurial build-base
+rm -rf /go
+rm -rf /var/cache/apk/*
+
+# backwards compatibility
+ln -fs /tmp/docker.sock /var/run/docker.sock

--- a/modules.go
+++ b/modules.go
@@ -7,5 +7,6 @@ import (
 	_ "github.com/gliderlabs/logspout/routesapi"
 	_ "github.com/gliderlabs/logspout/transports/tcp"
 	_ "github.com/gliderlabs/logspout/transports/udp"
+	_ "github.com/gliderlabs/logspout/transports/tls"
 	_ "github.com/iamatypeofwalrus/logspout-loggly/loggly"
 )


### PR DESCRIPTION
Currently logspout needs the build.sh to be added to the root of the repo (https://github.com/gliderlabs/logspout/tree/master/custom).

Also the tls support was added in logspout from the last build of the logspout-loggly.
